### PR TITLE
Fix window size change error of Google Chrome

### DIFF
--- a/Sources/Resize.swift
+++ b/Sources/Resize.swift
@@ -205,7 +205,7 @@ extension AXUIElement: Window {
     guard let size = AXValueCreate(.cgSize, &windowSize) else {
       return nil
     }
-    let err = AXUIElementSetAttributeValue(self, kAXWindowsAttribute as CFString, size)
+    let err = AXUIElementSetAttributeValue(self, Resize.SIZE, size)
     return OperationResult(code: err.rawValue)
   }
 


### PR DESCRIPTION

Fix bug in setSize for Google Chrome #1
===

Resolved a bug that caused setSize to fail specifically for Google Chrome. The attribute name `kAXWindowsAttribute` was incorrectly copied from another place. The code has been updated to use the correct attribute `Resize.SIZE` (`kAXSizeAttribute`) for size modification.
